### PR TITLE
Bump Tapioca to 0.16.9, and gem version to 0.0.17

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     boba (0.0.16)
       sorbet-static-and-runtime (~> 0.5)
-      tapioca (<= 0.16.7)
+      tapioca (~> 0.16.9)
 
 GEM
   remote: https://rubygems.org/
@@ -257,7 +257,7 @@ GEM
       mini_portile2 (~> 2.8.0)
     state_machines (0.6.0)
     stringio (3.1.1)
-    tapioca (0.16.7)
+    tapioca (0.16.9)
       benchmark
       bundler (>= 2.2.25)
       netrc (>= 0.11.0)

--- a/History.md
+++ b/History.md
@@ -1,5 +1,9 @@
 # Boba History
 
+## 0.0.17
+
+- Bump Tapioca
+
 ## 0.0.16
 
 - Bump Tapioca

--- a/boba.gemspec
+++ b/boba.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.0.0"
 
   spec.add_dependency("sorbet-static-and-runtime", "~> 0.5")
-  spec.add_dependency("tapioca", "<= 0.16.7")
+  spec.add_dependency("tapioca", "~> 0.16.9")
 end

--- a/boba.gemspec
+++ b/boba.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.0.0"
 
   spec.add_dependency("sorbet-static-and-runtime", "~> 0.5")
-  spec.add_dependency("tapioca", "~> 0.16.9")
+  spec.add_dependency("tapioca", "<= 0.16.9")
 end

--- a/lib/boba/version.rb
+++ b/lib/boba/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Boba
-  VERSION = "0.0.16"
+  VERSION = "0.0.17"
 end


### PR DESCRIPTION
Hi, I wanted to test out this gem, but we're using a newer version of Tapioca in our repo.

Changes
- Upgrade tapioca to 0.16.9.
- Changed the tapioca version requirement to `~>` from `<=`. Not sure if you intended `<=` but seemed odd to require only older versions and not newer ones. `~>` strikes a nice balance since it'll match all patch versions so you should need to bump it less frequently
- bump the version of this gem to 0.0.17 to reflect the Tapioca change

Let me know if there's anything else I can fix up!