### PR TITLE
chore: bump tapioca, allow versions up to 1.18

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    boba (0.1.2)
+    boba (0.1.4)
       sorbet-static-and-runtime (~> 0.5)
-      tapioca (<= 0.17.2)
+      tapioca (~> 0.17.4)
 
 GEM
   remote: https://rubygems.org/
@@ -270,7 +270,7 @@ GEM
       mini_portile2 (~> 2.8.0)
     state_machines (0.6.0)
     stringio (3.1.1)
-    tapioca (0.17.2)
+    tapioca (0.17.4)
       benchmark
       bundler (>= 2.2.25)
       netrc (>= 0.11.0)

--- a/History.md
+++ b/History.md
@@ -1,5 +1,13 @@
 # Boba History
 
+## 0.1.4
+
+- Bump Tapioca to v0.17.4, switch to pessimistic versioning.
+
+## 0.1.3
+
+- Bump Tapioca to v0.17.3.
+
 ## 0.1.2
 
 - Bump Tapioca to v0.17.2.

--- a/boba.gemspec
+++ b/boba.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.0.0"
 
   spec.add_dependency("sorbet-static-and-runtime", "~> 0.5")
-  spec.add_dependency("tapioca", "<= 0.17.2")
+  spec.add_dependency("tapioca", "~> 0.17.4")
 end

--- a/lib/boba/version.rb
+++ b/lib/boba/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Boba
-  VERSION = "0.1.2"
+  VERSION = "0.1.4"
 end


### PR DESCRIPTION
And another update today, haha... Also feel like probably ok to use pessimistic operator and allow tapioca < 1.18