### PR TITLE
Use Tapioca 0.17.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    boba (0.1.5)
+    boba (0.1.6)
       sorbet-static-and-runtime (~> 0.5)
-      tapioca (<= 0.17.7)
+      tapioca (<= 0.17.9)
 
 GEM
   remote: https://rubygems.org/
@@ -83,7 +83,7 @@ GEM
     attr_json (2.5.0)
       activerecord (>= 6.0.0, < 8.1)
     base64 (0.2.0)
-    benchmark (0.4.1)
+    benchmark (0.5.0)
     bigdecimal (3.1.8)
     builder (3.3.0)
     climate_control (0.2.0)
@@ -173,7 +173,7 @@ GEM
     parser (3.3.4.2)
       ast (~> 2.4.1)
       racc
-    prism (1.4.0)
+    prism (1.6.0)
     psych (5.1.2)
       stringio
     racc (1.8.1)
@@ -216,7 +216,7 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
-    rbi (0.3.6)
+    rbi (0.3.8)
       prism (~> 1.0)
       rbs (>= 3.4.4)
     rbs (4.0.0.dev.4)
@@ -228,7 +228,7 @@ GEM
     reline (0.5.10)
       io-console (~> 0.5)
     require-hooks (0.2.2)
-    rexml (3.4.1)
+    rexml (3.4.4)
     rubocop (1.65.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -250,15 +250,15 @@ GEM
       rubocop (>= 1)
     ruby-progressbar (1.13.0)
     securerandom (0.3.1)
-    sorbet (0.5.12356)
-      sorbet-static (= 0.5.12356)
-    sorbet-runtime (0.5.12356)
-    sorbet-static (0.5.12356-universal-darwin)
-    sorbet-static (0.5.12356-x86_64-linux)
-    sorbet-static-and-runtime (0.5.12356)
-      sorbet (= 0.5.12356)
-      sorbet-runtime (= 0.5.12356)
-    spoom (1.7.5)
+    sorbet (0.6.12825)
+      sorbet-static (= 0.6.12825)
+    sorbet-runtime (0.6.12825)
+    sorbet-static (0.6.12825-universal-darwin)
+    sorbet-static (0.6.12825-x86_64-linux)
+    sorbet-static-and-runtime (0.6.12825)
+      sorbet (= 0.6.12825)
+      sorbet-runtime (= 0.6.12825)
+    spoom (1.7.10)
       erubi (>= 1.10.0)
       prism (>= 0.28.0)
       rbi (>= 0.3.3)
@@ -270,15 +270,15 @@ GEM
       mini_portile2 (~> 2.8.0)
     state_machines (0.6.0)
     stringio (3.1.1)
-    tapioca (0.17.7)
+    tapioca (0.17.9)
       benchmark
       bundler (>= 2.2.25)
       netrc (>= 0.11.0)
       parallel (>= 1.21.0)
-      rbi (>= 0.3.1)
+      rbi (>= 0.3.7)
       require-hooks (>= 0.2.2)
       sorbet-static-and-runtime (>= 0.5.11087)
-      spoom (>= 1.7.0)
+      spoom (>= 1.7.9)
       thor (>= 1.2.0)
       yard-sorbet
     terrapin (0.6.0)
@@ -293,7 +293,7 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.37)
+    yard (0.9.38)
     yard-sorbet (0.9.0)
       sorbet-runtime
       yard

--- a/History.md
+++ b/History.md
@@ -1,5 +1,10 @@
 # Boba History
 
+## 0.1.6
+
+- Bump Tapioca to v0.17.9.
+- Fix Sorbet type annotations for `Module` to use `T::Module[T.anything]` for compatibility with Sorbet 0.6.x.
+
 ## 0.1.5
 
 - Bump Tapioca to v0.17.7.

--- a/boba.gemspec
+++ b/boba.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.0.0"
 
   spec.add_dependency("sorbet-static-and-runtime", "~> 0.5")
-  spec.add_dependency("tapioca", "<= 0.17.7")
+  spec.add_dependency("tapioca", "<= 0.17.9")
 end

--- a/lib/boba/version.rb
+++ b/lib/boba/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Boba
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end

--- a/lib/tapioca/dsl/compilers/active_record_relation_types.rb
+++ b/lib/tapioca/dsl/compilers/active_record_relation_types.rb
@@ -56,7 +56,7 @@ module Tapioca
         class << self
           extend T::Sig
 
-          sig { override.returns(T::Enumerable[Module]) }
+          sig { override.returns(T::Enumerable[T::Module[T.anything]]) }
           def gather_constants
             Tapioca::Dsl::Compilers::ActiveRecordRelations.gather_constants
           end

--- a/lib/tapioca/dsl/compilers/flag_shih_tzu.rb
+++ b/lib/tapioca/dsl/compilers/flag_shih_tzu.rb
@@ -57,7 +57,7 @@ module Tapioca
         class << self
           extend T::Sig
 
-          sig { override.returns(T::Enumerable[Module]) }
+          sig { override.returns(T::Enumerable[T::Module[T.anything]]) }
           def gather_constants
             all_classes.select { |c| c < ::FlagShihTzu }
           end

--- a/lib/tapioca/dsl/compilers/kaminari.rb
+++ b/lib/tapioca/dsl/compilers/kaminari.rb
@@ -60,7 +60,7 @@ module Tapioca
         class << self
           extend T::Sig
 
-          sig { override.returns(T::Enumerable[Module]) }
+          sig { override.returns(T::Enumerable[T::Module[T.anything]]) }
           def gather_constants
             descendants_of(::ActiveRecord::Base).reject(&:abstract_class?)
           end

--- a/lib/tapioca/dsl/compilers/money_rails.rb
+++ b/lib/tapioca/dsl/compilers/money_rails.rb
@@ -60,7 +60,7 @@ module Tapioca
         class << self
           extend T::Sig
 
-          sig { override.returns(T::Enumerable[Module]) }
+          sig { override.returns(T::Enumerable[T::Module[T.anything]]) }
           def gather_constants
             all_classes.select { |c| c < ::MoneyRails::ActiveRecord::Monetizable }
           end

--- a/lib/tapioca/dsl/compilers/paperclip.rb
+++ b/lib/tapioca/dsl/compilers/paperclip.rb
@@ -43,7 +43,7 @@ module Tapioca
         class << self
           extend T::Sig
 
-          sig { override.returns(T::Enumerable[Module]) }
+          sig { override.returns(T::Enumerable[T::Module[T.anything]]) }
           def gather_constants
             all_classes.select { |c| c < ::Paperclip::Glue }
           end

--- a/lib/tapioca/dsl/compilers/state_machines_extended.rb
+++ b/lib/tapioca/dsl/compilers/state_machines_extended.rb
@@ -119,7 +119,7 @@ module Tapioca
           "GeneratedAssociationRelationMethods",
         ].freeze
 
-        ConstantType = type_member { { fixed: T.all(Module, ::StateMachines::ClassMethods) } }
+        ConstantType = type_member { { fixed: T.all(T::Module[T.anything], ::StateMachines::ClassMethods) } }
 
         sig { override.void }
         def decorate
@@ -168,7 +168,7 @@ module Tapioca
         class << self
           extend T::Sig
 
-          sig { override.returns(T::Enumerable[Module]) }
+          sig { override.returns(T::Enumerable[T::Module[T.anything]]) }
           def gather_constants
             all_classes.select { |mod| ::StateMachines::InstanceMethods > mod }
           end
@@ -176,7 +176,7 @@ module Tapioca
 
         private
 
-        sig { params(constant: Module).returns(T::Boolean) }
+        sig { params(constant: T::Module[T.anything]).returns(T::Boolean) }
         def uses_active_record_integration?(constant)
           ::StateMachines::Integrations.match(constant)&.integration_name == :active_record
         end


### PR DESCRIPTION
## Overview
Boba is using an outdated version of Tapioca, which leads to key commands like `bin/tapioca gems` and `bin/tapioca dsl` failing.

As part of this, uses `T::Module` properly to align with Tapioca's intent with this change. That functionality is described [here](https://github.com/sorbet/sorbet/pull/8076).

**Bumps Tapioca dependency version, makes minimal changes necessary for support, and bumps Boba version**

### Type-checking:
<img width="429" height="96" alt="image" src="https://github.com/user-attachments/assets/a6e5653c-3199-40e8-a7a2-f68ce89f1334" />

### Tests:
<img width="847" height="158" alt="image" src="https://github.com/user-attachments/assets/7b5ddf52-b875-438e-927b-19d72a30ae78" />

Closes https://github.com/angellist/boba/issues/17 , which links to the appropriate errors as documented by Tapioca themsleves.

### Manual Testing
Real repo, pointing to my fork instead of released boba

Before: 
<img width="1270" height="432" alt="image" src="https://github.com/user-attachments/assets/13b319dd-4f99-4542-8d29-9cb9fa256c19" />

After:
<img width="813" height="387" alt="image" src="https://github.com/user-attachments/assets/8ff7ffbc-a5f0-4d01-947d-a936ec32a266" />


