### PR TITLE
Fix Shrine compiler for anonymous splat / block parameters

### DIFF
--- a/lib/tapioca/dsl/compilers/shrine.rb
+++ b/lib/tapioca/dsl/compilers/shrine.rb
@@ -47,8 +47,6 @@ module Tapioca
       # end
       # ~~~
       class Shrine < Tapioca::Dsl::Compiler
-        include RBIHelper
-
         InstanceMethodModuleName = "ShrineGeneratedMethods"
         ClassMethodModuleName = "ShrineGeneratedClassMethods"
 
@@ -149,11 +147,16 @@ module Tapioca
           end
         end
 
-        #: (UnboundMethod | Method method_obj) -> Array[RBI::TypedParam]
+        # Compiles a `Method` / `UnboundMethod#parameters` into the `RBI::TypedParam`
+        # array expected by `RBI::Scope#create_method`. Argument types default to
+        # `T.untyped` since shrine plugins don't carry sigs. Anonymous parameter names
+        # — including empty names and the special tokens `:*`, `:**`, `:&` — are
+        # replaced with `_arg{index}` so the generated RBI is syntactically valid.
+        #: ((Method | UnboundMethod) method_obj) -> Array[RBI::TypedParam]
         def compile_parameters(method_obj)
-          method_obj.parameters.filter_map do |(type, name)|
+          method_obj.parameters.each_with_index.filter_map do |(type, name), index|
             name_str = name.to_s
-            name_str = "arg" if name_str.empty?
+            name_str = "_arg#{index}" unless name_str.match?(/\A[A-Za-z_][A-Za-z0-9_]*\z/)
             case type
             when :req
               create_param(name_str, type: "T.untyped")

--- a/spec/tapioca/dsl/compilers/shrine_spec.rb
+++ b/spec/tapioca/dsl/compilers/shrine_spec.rb
@@ -255,6 +255,63 @@ module Tapioca
               assert_includes(rbi, "def file_custom_meta; end")
               assert_includes(rbi, "T.untyped")
             end
+
+            it "synthesizes parameter names for anonymous splat / block parameters" do
+              # Anonymous splat parameters (`def m(*, **, &)`) come back from
+              # `Method#parameters` as the special symbols `:*`, `:**`, `:&`. Without
+              # the indexed fallback in `compile_parameters`, those would be emitted
+              # verbatim and produce unparseable RBI (`def file_anon(**, ****, &&)`
+              # plus a sig with invalid keyword names).
+              add_ruby_file("schema.rb", <<~RUBY)
+                ActiveRecord::Migration.suppress_messages do
+                  ActiveRecord::Schema.define do
+                    create_table :records do |t|
+                      t.text :file_data
+                    end
+                  end
+                end
+              RUBY
+
+              add_ruby_file("anon_plugin.rb", <<~RUBY)
+                class Shrine
+                  module Plugins
+                    module AnonSplatPlugin
+                      module AttachmentMethods
+                        private
+
+                        def define_entity_methods(name)
+                          super
+
+                          module_eval(<<~METHOD, __FILE__, __LINE__ + 1)
+                            def \#{name}_forward(*, **, &)
+                              nil
+                            end
+                          METHOD
+                        end
+                      end
+                    end
+
+                    register_plugin(:anon_splat_plugin, AnonSplatPlugin)
+                  end
+                end
+              RUBY
+
+              add_ruby_file("file_uploader.rb", <<~RUBY)
+                class FileUploader < Shrine
+                  plugin :model
+                  plugin :anon_splat_plugin
+                end
+              RUBY
+
+              add_ruby_file("record.rb", <<~RUBY)
+                class Record < ActiveRecord::Base
+                  include FileUploader::Attachment(:file)
+                end
+              RUBY
+
+              rbi = rbi_for(:Record)
+              assert_includes(rbi, "def file_forward(*_arg0, **_arg1, &_arg2); end")
+            end
           end
         end
       end


### PR DESCRIPTION
## Summary
Fixes a bug where the Shrine DSL compiler emits invalid RBI when a Shrine plugin defines a method using anonymous splat (`*`), double-splat (`**`), or block (`&`) parameters.

## Bug
`Method#parameters` returns the special symbols `:*`, `:**`, `:&` for anonymous splat / block parameters. The previous `compile_parameters` only fell back to a synthetic name when the parameter name was empty, so these special symbols were emitted verbatim and produced unparseable RBI:

```ruby
# Plugin defines:
def #{name}_forward(*, **, &)
  nil
end

# Old (broken) compiler output:
def file_forward(**, ****, &&); end
sig { params(*: T.untyped, **: T.untyped, &: T.untyped).returns(T.untyped) }
```

The fallback also reused the literal name `arg` for every empty parameter name, which would collide in any method with multiple unnamed positional parameters.

## Fix
`compile_parameters` now replaces *any* parameter name that isn't a valid Ruby identifier with an indexed fallback `_arg{N}`, where `N` is the parameter's position in the method's signature. This handles both the empty-name case and the `:*` / `:**` / `:&` cases without collisions.

```ruby
# New compiler output:
def file_forward(*_arg0, **_arg1, &_arg2); end
sig { params(_arg0: T.untyped, _arg1: T.untyped, _arg2: T.untyped).returns(T.untyped) }
```

## Test
Added a regression spec — `synthesizes parameter names for anonymous splat / block parameters` — that registers a Shrine plugin defining a method with `(*, **, &)` and asserts the generated RBI is syntactically valid.

## Context
Split out from #28 at @stathis-alexander's [request](https://github.com/angellist/boba/pull/28#discussion_r3168356322) so this bug fix gets its own line in the auto-generated release notes.
