### PR TITLE
Pin GitHub actions with SHA and add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,65 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "12:00" # UTC
+    groups:
+      bundler-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+        exclude-patterns:
+          - "rails"
+          - "actioncable"
+          - "actionmailbox"
+          - "actionmailer"
+          - "actionpack"
+          - "actiontext"
+          - "actionview"
+          - "activejob"
+          - "activemodel"
+          - "activerecord"
+          - "activestorage"
+          - "activesupport"
+          - "railties"
+          - "rubocop"
+          - "rubocop-*"
+      bundler-rails:
+        patterns:
+          - "rails"
+          - "actioncable"
+          - "actionmailbox"
+          - "actionmailer"
+          - "actionpack"
+          - "actiontext"
+          - "actionview"
+          - "activejob"
+          - "activemodel"
+          - "activerecord"
+          - "activestorage"
+          - "activesupport"
+          - "railties"
+      bundler-rubocop:
+        patterns:
+          - "rubocop"
+          - "rubocop-*"
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/"
+      - "/.github/actions/*"
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "12:00" # UTC
+    groups:
+      github-actions-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Linters
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.131.0
         with:
           bundler-cache: true
       - name: Run type check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Create release
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           script: |
@@ -29,10 +29,10 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.131.0
         with:
           bundler-cache: true
       - name: Publish to RubyGems
-        uses: rubygems/release-gem@e9a6361a0b14562539327c2a02373edc56dd3169 # v1.1.4
+        uses: rubygems/release-gem@6317d8d1f7e28c24d28f6eff169ea854948bd9f7 # v1.2.0


### PR DESCRIPTION
This PR pins all GitHub Actions with their full-length commit SHA, bumps all of them to their latest versions, and adds a Dependabot configuration to keep both GitHub Actions and Ruby development dependencies up-to-date.

If you accept this PR, I would also highly recommend that you check the "Require actions to be pinned to a full-length commit SHA" checkbox under Settings > Actions > General.

Up to you whether you want to merge this or not, but in this age of constant supply chain attacks where even GitHub Actions can be an attack vector, I think all open-source libraries should be mindful of this.

As configured, Dependabot will run once a week on Mondays, and open:
- a single PR to bump all GitHub Actions for minor and patch updates
- a single PR to bump Ruby dependencies for minor and patch updates
    - (this only applies to development dependencies since boba is a Ruby gem -- won't affect downstream users)
- one PR for each major version update
    - will group updates for all Rails gems and all Rubocop gems, since those typically need to be updated at the same time

This is what we do at $job and we are pretty happy with it.
